### PR TITLE
Fix for-in field markers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ ${1:myArray}.forEach(function (${2:elem}) {
 ### [fi] for in
 
 ```javascript
-for (var ${1:prop} in ${1:obj}) {
-  if (${1:obj}.hasOwnProperty(${1:prop})) {
+for (var ${1:prop} in ${2:obj}) {
+  if (${2:obj}.hasOwnProperty(${1:prop})) {
     ${3:// body...}
   }
 }


### PR DESCRIPTION
There was a typo in README.md in for-in snippet documentation: wrong field markers (`${1:}` instead of `${2:}`).
This fixes it.
